### PR TITLE
优化漫游组件

### DIFF
--- a/src/core/roaming/RoamingController.js
+++ b/src/core/roaming/RoamingController.js
@@ -63,11 +63,7 @@ class RoamingController {
   play() {
     this._viewer.clock.shouldAnimate = true
     this._viewer.clock.currentTime = this._startTime || Cesium.JulianDate.now()
-    this._postUpdateRemoveCallback && this._postUpdateRemoveCallback()
-    this._postUpdateRemoveCallback = this._viewer.scene.postUpdate.addEventListener(
-      this._onPostUpdate,
-      this
-    )
+    this._addPostUpdateListener()
     return this
   }
 
@@ -78,6 +74,8 @@ class RoamingController {
     this._viewer.clock.shouldAnimate = false
     this._viewer.camera.lookAtTransform(Cesium.Matrix4.IDENTITY)
     this._viewer.delegate.trackedEntity = undefined
+    // 删除 postUpdate 监听
+    this._removePostUpdateListener()
     return this
   }
 
@@ -86,7 +84,21 @@ class RoamingController {
    */
   restore() {
     this._viewer.clock.shouldAnimate = true
+    // 继续时重新监听事件
+    this._addPostUpdateListener()
     return this
+  }
+
+  _addPostUpdateListener() {
+    this._postUpdateRemoveCallback && this._postUpdateRemoveCallback()
+    this._postUpdateRemoveCallback = this._viewer.scene.postUpdate.addEventListener(
+      this._onPostUpdate,
+      this
+    )
+  }
+
+  _removePostUpdateListener() {
+    this._viewer.scene.postUpdate.removeEventListener(this._onPostUpdate, this)
   }
 
   /**

--- a/src/core/roaming/RoamingPath.js
+++ b/src/core/roaming/RoamingPath.js
@@ -189,7 +189,11 @@ class RoamingPath {
         let WGS84TickPosition = Transform.transformCartesianToWGS84(
           tickPosition
         )
-        WGS84TickPosition.alt = viewOption.alt || 5
+        // 当没有在 Controller 设置统一的高度时，采用每个坐标的高度。
+        // 这样能保证漫游路径哪怕是不完全在一个水平面高度都能实现
+        if (!isNaN(viewOption.alt)) {
+          WGS84TickPosition.alt = viewOption.alt
+        }
         camera.lookAt(
           Transform.transformWGS84ToCartesian(WGS84TickPosition),
           new Cesium.HeadingPitchRange(


### PR DESCRIPTION
1.解决漫游暂停后没有释放相机的问题。
参考：https://github.com/dvgis/dc-plugins/issues/6

2.解决没办法漫游一批数据的高度不一致的数据。当完全不设置 Controller 的 alt 参数时，直接采用 RoamingPath 的 position 高度自动计算
``` js
// 当没有在 Controller 设置统一的高度时，采用每个坐标的高度。
// 这样能保证漫游路径哪怕是不完全在一个水平面高度都能实现
if (!isNaN(viewOption.alt)) {
  WGS84TickPosition.alt = viewOption.alt
}
```